### PR TITLE
Added new system for default setups.

### DIFF
--- a/chaosSimulator/src/chaosSimulator/DefaultSetups.java
+++ b/chaosSimulator/src/chaosSimulator/DefaultSetups.java
@@ -1,11 +1,13 @@
 package chaosSimulator;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 public class DefaultSetups {
 	
 	private static int homeX = Main.screensize.width/2;
 	private static int homeY = Main.screensize.width/2;
+	private static int distance = 20;
 	
 	public enum DEFAULTSETUPS {
 		SQUARE, TRIANGLE, HEXAGON, GRID, CIRCLE, CROSS
@@ -13,6 +15,7 @@ public class DefaultSetups {
 	private static int numOfSetups = 6; //THIS MUST BE CHANGED TO MATCH THE NUMBER OF ITEMS IN THE ENUM
 	
 	public static DEFAULTSETUPS setup = null;
+	public static HashMap<String, ArrayList<Magnet>> defaultSetups = new HashMap<String, ArrayList<Magnet>>();
 	
 	public static int getNumOfSetups() {
 		return numOfSetups;
@@ -43,6 +46,29 @@ public class DefaultSetups {
 		world.addMagnet(new Magnet(450,400,-world.getDefaultCoef()));
 		world.addMagnet(new Magnet(400,350,-world.getDefaultCoef()));
 		world.addMagnet(new Magnet(400,450,-world.getDefaultCoef()));
+	}
+	public static void createDefaultSetups(World world) {
+		ArrayList<Magnet> temp;
+		
+		//SQUARE
+		temp = new ArrayList<Magnet>();
+		temp.add(new Magnet(homeX,homeY+distance,world.getDefaultCoef()));
+		temp.add(new Magnet(homeX+distance,homeY+distance,world.getDefaultCoef()));
+		temp.add(new Magnet(homeX+distance,homeY,world.getDefaultCoef()));
+		temp.add(new Magnet(homeX+distance,homeY-distance,world.getDefaultCoef()));
+		temp.add(new Magnet(homeX,homeY-distance,world.getDefaultCoef()));
+		temp.add(new Magnet(homeX-distance,homeY-distance,world.getDefaultCoef()));
+		temp.add(new Magnet(homeX-distance,homeY,world.getDefaultCoef()));
+		temp.add(new Magnet(homeX-distance,homeY+distance,world.getDefaultCoef()));
+		//adding SQUARE
+		defaultSetups.put("SQUARE", temp);
+		
+		//SETUP2
+		temp = new ArrayList<Magnet>();
+		//here add magnets to temp
+		
+		//defaultSetups.put("SETUP2", temp);
+		//uncomment above line to add setup2 to the default setups list
 	}
 
 

--- a/chaosSimulator/src/chaosSimulator/Main.java
+++ b/chaosSimulator/src/chaosSimulator/Main.java
@@ -13,6 +13,9 @@ public class Main extends JFrame{
 		//creates a the DisplayPanel
 		DisplayPanel dp = new DisplayPanel();
 		
+		//creates default setups
+		DefaultSetups.createDefaultSetups(dp.getWorld());
+		
 		//creates the JFrame with these parameters
 		this.setTitle("This shit is magnets");
 		this.setSize(screensize);

--- a/chaosSimulator/src/chaosSimulator/MouseListener.java
+++ b/chaosSimulator/src/chaosSimulator/MouseListener.java
@@ -47,6 +47,7 @@ public class MouseListener extends MouseAdapter{
 		if(displayPanel.state == STATES.shapes) {
 			for(int i=0; i<DefaultSetups.getNumOfSetups(); i++) {
 				DefaultSetups.setup = DEFAULTSETUPS.values()[i];
+				//Eric's button stuff should go here, and when a button for a particular shape setup is clicked, it should call this.useSetup("nameofsetup");
 			}
 		}
 		
@@ -117,5 +118,17 @@ public class MouseListener extends MouseAdapter{
 	
 	public void mouseMoved(MouseEvent e) {
 		
+	}
+	
+	public void useSetup(String setup) {
+		ArrayList<Magnet> setupMagnets = DefaultSetups.defaultSetups.get(setup);
+		if(DefaultSetups.defaultSetups.containsKey(setup)) {
+			for(int i = 0; i < setupMagnets.size(); i++) {
+				displayPanel.getWorld().addMagnet(setupMagnets.get(i));
+			}
+		}
+		else {
+			System.out.print("THE VALUE ASSIGNED TO SETUP BUTTON HAS NO MAGNET SETUP ATTACHED TO IT");
+		}
 	}
 }

--- a/chaosSimulator/src/chaosSimulator/World.java
+++ b/chaosSimulator/src/chaosSimulator/World.java
@@ -37,8 +37,7 @@ public class World {
 			posArrayY[i] = i * 10;
 		}
 		
-		//DefaultSetups.setup1(this);
-		DefaultSetups.setup2(this);
+		
 		
 	}
 	


### PR DESCRIPTION
New system for default setup shapes. Alternative to the weird enums/lambda function thing we were doing before. Basically, setups (ArrayLists of Magnet objects) are stored in a HashMap. I didn't have Eric's button setup when I made this, since he hasn't pushed it, but all you need to do to combine the two would be to make it so that when a button on the shapes screen is pushed, it calls ' this.useSetup("nameofsetup"); '. You can create default setups in the createDefaultSetups method in the DefaultSetups class. Just use the square setup I put in as a guide.

I also didn't delete Eric's square and setup2 functions, or his enumerator for shapes, but they're both essentially useless if we use this code.